### PR TITLE
Support Laravel 6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "type": "library",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.1",
-        "illuminate/console": "~5.1"
+        "illuminate/support": ">=5.1",
+        "illuminate/console": ">=5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
Fix error in installing package caused by inappropriate `illuminate/console` version.